### PR TITLE
feat: add CLI to synchronize past hevy workouts to strava by cloning them to trigger hevy backend strava sync

### DIFF
--- a/CLONE_FEATURES.md
+++ b/CLONE_FEATURES.md
@@ -1,0 +1,41 @@
+# Workout Cloning and Strava Sync Features
+
+This update adds the ability to clone existing Hevy workouts via the command line. This is useful for pushing previous workouts to Strava, which cannot be done natively in the Hevy app for already-saved workouts.
+
+## New CLI Tools
+
+### 1. Manual Login Helper (`manual_login.py`)
+If you are running in an environment without a GUI (like WSL2), you can use this script to log in by copying your session cookie from your Windows browser.
+
+**How to use:**
+1. Open your web browser on Windows and log in to [hevy.com](https://hevy.com).
+2. Open **Developer Tools** (press **F12**).
+3. Go to the **Application** tab (Chrome/Edge) or **Storage** tab (Firefox).
+4. Select **Cookies** -> `https://www.hevy.com`.
+5. Find the cookie named `access-token`.
+6. Copy its entire value.
+7. In your terminal, run:
+   ```bash
+   python3 manual_login.py
+   ```
+8. Paste the cookie value when prompted. Your session will now be saved locally.
+
+### 2. Workout Cloning Tool (`clone_to_strava.py`)
+This script clones a local workout and submits it to Hevy with the `share_to_strava` flag set to `True`.
+
+**How to use:**
+1. First, ensure you have downloaded your latest workouts from Hevy:
+   ```bash
+   python3 clone_to_strava.py --sync
+   ```
+2. List your recent workouts and choose one to clone:
+   ```bash
+   python3 clone_to_strava.py --list
+   ```
+3. Enter the number corresponding to the workout you want to sync to Strava.
+
+The script will create an identical copy of the workout (preserving the original timestamps) and submit it as a new workout to Hevy. Hevy's backend will then automatically push this new workout to your connected Strava account.
+
+## Backend Changes (`hevy_api.py`)
+- Added `prepare_workout_for_clone(workout_data)`: Robustly cleans workout data by removing internal IDs and mapping fields to the v2 API format.
+- Added `post_workout(workout_json)`: Handles the actual submission of the cloned workout to the Hevy API.

--- a/clone_to_strava.py
+++ b/clone_to_strava.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Clone to Strava
+
+A utility script to clone an existing Hevy workout and push it to Strava.
+This works by creating an identical copy of the workout with a new ID
+and setting the 'share_to_strava' flag to True.
+"""
+
+import json
+import os
+import sys
+import uuid
+import random
+import requests
+from pathlib import Path
+import hevy_api
+
+def clone_workout(workout_file_path):
+    # 1. Check if logged in to Hevy
+    logged_in, user_folder, auth_token = hevy_api.is_logged_in()
+    if not logged_in:
+        print("Error: Not logged in to Hevy. Please run Under The Bar and log in first.")
+        return False
+
+    # 2. Load the workout JSON
+    try:
+        with open(workout_file_path, 'r') as f:
+            workout_data = json.load(f)
+    except Exception as e:
+        print(f"Error loading workout file: {e}")
+        return False
+
+    # 3. Prepare the clone using the helper
+    clone_data = hevy_api.prepare_workout_for_clone(workout_data)
+    w = clone_data["workout"]
+
+    # 6. Post to Hevy
+    print(f"Cloning workout '{w.get('title')}' ({w.get('start_time')}) to Hevy with Strava sync...")
+    
+    try:
+        status_code, response_text = hevy_api.post_workout(clone_data)
+        
+        if status_code in (200, 201):
+            print("Successfully cloned workout! Hevy should now push it to your Strava account.")
+            print(f"New Hevy Workout ID: {w['workout_id']}")
+            return True
+        else:
+            print(f"Failed to clone workout. Status code: {status_code}")
+            print(f"Response: {response_text}")
+            return False
+    except Exception as e:
+        print(f"Error during API request: {e}")
+        return False
+
+def list_local_workouts():
+    logged_in, user_folder, auth_token = hevy_api.is_logged_in()
+    if not logged_in:
+        print("Error: Not logged in to Hevy.")
+        return []
+
+    workouts_folder = Path(user_folder) / "workouts"
+    if not workouts_folder.exists():
+        print(f"Workouts folder not found: {workouts_folder}")
+        return []
+
+    workouts = []
+    for file in sorted(os.listdir(workouts_folder), reverse=True):
+        if file.endswith(".json") and file.startswith("workout_"):
+            try:
+                with open(workouts_folder / file, 'r') as f:
+                    data = json.load(f)
+                    # Handle both wrapped and unwrapped
+                    w = data.get("workout", data)
+                    workouts.append({
+                        "filename": file,
+                        "path": str(workouts_folder / file),
+                        "title": w.get("title", "Untitled"),
+                        "start_time": w.get("start_time", 0)
+                    })
+            except:
+                continue
+    return workouts
+
+if __name__ == "__main__":
+    import argparse
+    import datetime
+
+    parser = argparse.ArgumentParser(description="Clone a Hevy workout to push it to Strava.")
+    parser.add_argument("--file", help="Path to the workout JSON file.")
+    parser.add_argument("--list", action="store_true", help="List local workouts to choose from.")
+    parser.add_argument("--sync", action="store_true", help="Download latest workouts from Hevy first.")
+
+    args = parser.parse_args()
+
+    if args.sync:
+        print("Syncing workouts from Hevy...")
+        status, havesome = hevy_api.batch_download()
+        if status == 200:
+            print("Sync complete.")
+        else:
+            print(f"Sync failed with status: {status}")
+
+    if args.list:
+        workouts = list_local_workouts()
+        if not workouts:
+            print("No local workouts found.")
+            print("Try running with --sync first: python3 clone_to_strava.py --sync --list")
+        else:
+            print("\nRecent local workouts:")
+            for i, w in enumerate(workouts[:20]):
+                dt = datetime.datetime.fromtimestamp(w["start_time"])
+                print(f"[{i}] {dt.strftime('%Y-%m-%d %H:%M')} - {w['title']} ({w['filename']})")
+            
+            choice = input("\nEnter the number of the workout to clone (or 'q' to quit): ")
+            if choice.lower() != 'q':
+                try:
+                    idx = int(choice)
+                    if 0 <= idx < len(workouts):
+                        clone_workout(workouts[idx]["path"])
+                    else:
+                        print("Invalid selection.")
+                except ValueError:
+                    print("Please enter a number.")
+    elif args.file:
+        clone_workout(args.file)
+    else:
+        parser.print_help()
+        print("\nExample: python3 clone_to_strava.py --list")

--- a/hevy_api.py
+++ b/hevy_api.py
@@ -12,6 +12,7 @@ import re
 import time
 import datetime
 import shutil
+import uuid
 
 from pathlib import Path
 import concurrent.futures 
@@ -1109,6 +1110,91 @@ def cheer_squad():
 	with open(user_folder+"/"+"squad.json", 'w') as f:
 		json.dump(new_squad_data, f, indent=4)
 		
+
+#
+# Post a workout to Hevy
+# can include share_to_strava: True to push to Strava
+#
+def post_workout(workout_json):
+    # Make sure user is logged in
+    user_data = is_logged_in()
+    if user_data[0] == False:
+        return 403
+    auth_token = user_data[2]
+    
+    headers = BASIC_HEADERS.copy()
+    headers["Authorization"] = "Bearer " + auth_token
+    
+    s = requests.Session()
+    r = s.post('https://api.hevyapp.com/v2/workout', data=json.dumps(workout_json), headers=headers)
+    return r.status_code, r.text
+
+def prepare_workout_for_clone(workout_data):
+    """Refines the workout data to be compatible with Hevy API v2 POST."""
+    # Handle both wrapped and unwrapped data
+    if "workout" in workout_data:
+        original_w = workout_data["workout"]
+    else:
+        original_w = workout_data
+
+    # Create a fresh workout structure based on what v2 expects
+    w = {}
+    w["workout_id"] = str(uuid.uuid4())
+    w["title"] = original_w.get("name") or original_w.get("title") or "Cloned Workout"
+    w["description"] = original_w.get("description", "")
+    if w["description"]:
+        w["description"] += "\n\n(Cloned to Strava via Under The Bar)"
+    else:
+        w["description"] = "(Cloned to Strava via Under The Bar)"
+    
+    w["start_time"] = original_w.get("start_time")
+    w["end_time"] = original_w.get("end_time")
+    w["media"] = []
+    w["apple_watch"] = original_w.get("apple_watch", False)
+    w["wearos_watch"] = original_w.get("wearos_watch", False)
+    w["is_private"] = original_w.get("is_private", False)
+    w["is_biometrics_public"] = original_w.get("is_biometrics_public", True)
+
+    # Process exercises
+    w["exercises"] = []
+    for old_ex in original_w.get("exercises", []):
+        new_ex = {
+            "title": old_ex.get("title"),
+            "exercise_template_id": old_ex.get("exercise_template_id"),
+            "notes": old_ex.get("notes", ""),
+            "rest_timer_seconds": old_ex.get("rest_seconds") or old_ex.get("rest_timer_seconds") or 0,
+            "volume_doubling_enabled": old_ex.get("volume_doubling_enabled", False),
+            "sets": []
+        }
+        
+        # Process sets
+        for old_set in old_ex.get("sets", []):
+            new_set = {
+                "index": old_set.get("index", 0),
+                "type": old_set.get("type") or old_set.get("indicator") or "normal",
+                "weight_kg": old_set.get("weight_kg"),
+                "reps": old_set.get("reps"),
+                "rpe": old_set.get("rpe"),
+                "distance_meters": old_set.get("distance_meters"),
+                "duration_seconds": old_set.get("duration_seconds"),
+                "completed_at": old_set.get("completed_at")
+            }
+            new_ex["sets"].append(new_set)
+            
+        w["exercises"].append(new_ex)
+
+    # Wrap in the final payload
+    clone_data = {
+        "workout": w,
+        "share_to_strava": True
+    }
+    
+    # Add Strava activity local time if we have it
+    if w["start_time"]:
+        dt = datetime.datetime.fromtimestamp(w["start_time"], datetime.timezone.utc)
+        clone_data["strava_activity_local_time"] = dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    return clone_data
 
 if __name__ == "__main__":
 	#print(login_cli())

--- a/manual_login.py
+++ b/manual_login.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import hevy_api
+import getpass
+import json
+import urllib.parse
+
+print("--- Hevy Manual Login Helper ---")
+print("Since you are on WSL without a GUI backend, you can log in manually.")
+print("\n1. Log in to https://hevy.com on your Windows browser.")
+print("2. Open DevTools (F12) -> Application (or Storage) -> Cookies -> https://www.hevy.com")
+print("3. Find the cookie named 'auth2.0-token'.")
+print("4. Copy the entire value (it looks like %7B%22access_token%22%3A...)")
+
+cookie_value = input("\nPaste the 'auth2.0-token' cookie value here: ").strip()
+
+try:
+    # URL decode and parse JSON
+    decoded_value = urllib.parse.unquote(cookie_value)
+    data = json.loads(decoded_value)
+    
+    access_token = data.get("access_token")
+    refresh_token = data.get("refresh_token")
+    
+    if not access_token or not refresh_token:
+        print("Error: Could not find access_token or refresh_token in the pasted value.")
+    else:
+        print("\nAttempting to log in...")
+        status = hevy_api.temp_login(access_token, refresh_token)
+        if status == 200:
+            print("\nSuccess! You are now logged in.")
+            print("You can now run: python3 clone_to_strava.py --list")
+        else:
+            print(f"\nFailed to log in. Hevy API returned status: {status}")
+
+except Exception as e:
+    print(f"\nError parsing cookie: {e}")
+    print("Make sure you copied the entire cookie value from your browser.")


### PR DESCRIPTION
This vibecoded PR adds a CLI that allows to synchronize past Hevy workouts to strava, which is natively not possible, by creating a clone of the original workout, which triggers the strava sync in hevy backend

Useful for those who use strava to keep track of every workout they did no matter the app, and who didn't have strava before hevy or who forgot to enable strava sync before their first hevy workouts

I used it for myself using this repository's code as a base, thought that could be useful to someone hence the PR.

Note that it doesn't delete the newly created workout or the original one, it's up to the user to enhance the code to do it and double check if the new workout data was preserved (was the case for myself apart from RPE that was lost, but I changed the code to include it without testing again as I deleted the orignal workout containing the RPE 😄)

Note that there is no GUI integration as I couldn't have it from wsl, hence the `manual_login.py `file